### PR TITLE
Get unit tests passing with htmlwidgets 1.6

### DIFF
--- a/clinUtils/tests/testthat/test_knitPrintListPlots.R
+++ b/clinUtils/tests/testthat/test_knitPrintListPlots.R
@@ -148,8 +148,8 @@ test_that("A list of interactive plots (plotly) is correctly included", {
       expect_silent(outputRmd <- rmarkdown::render(file, quiet = TRUE))
       
       outputHTMLPlots <- readLines(outputRmd)
-      expect_length(grep("class=\"plotly html-widget\"", outputHTMLPlots), 2)
-      
+      expect_length(grep('class="plotly html-widget', outputHTMLPlots), 2)
+
     })
 
 test_that("A list of interactive objects (plotly) is correctly included", {
@@ -166,8 +166,8 @@ test_that("A list of interactive objects (plotly) is correctly included", {
       )
       expect_silent(outputRmd <- rmarkdown::render(file, quiet = TRUE))
       outputHTMLObjects <- readLines(outputRmd)
-      expect_length(grep("class=\"plotly html-widget\"", outputHTMLObjects), 2)
-      
+      expect_length(grep('class="plotly html-widget', outputHTMLObjects), 2)
+
     })
 
 test_that("A list of interactive table objects (flextable) is correctly included", {


### PR DESCRIPTION
htmlwidgets 1.6 (soon to be released) adds a `fill` parameter to `sizingPolicy()`/`shinyWidgetOutput()`, which when `TRUE` (the default), some additional CSS classes are added to the containing element.

This PR updates a unit test to accommodate for the new 1.6 result.

I plan on submitting htmlwidgets 1.6 to CRAN within the next couple weeks. If you could please submit this patch fix to CRAN before then, it'd be much appreciated.
